### PR TITLE
Fix linux warning

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -97,12 +97,20 @@ pub async fn on_context_menu<R: Runtime>(
             // Show the context menu at the specified position.
             let gdk_window = gtk_window.window().unwrap();
             let rect = &gdk::Rectangle::new(x, y, 0, 0);
+            let mut event = gdk::Event::new(gdk::EventType::ButtonPress);
+            event.set_device(
+                gdk_window
+                    .display()
+                    .default_seat()
+                    .and_then(|d| d.pointer())
+                    .as_ref(),
+            );
             menu.popup_at_rect(
                 &gdk_window,
                 rect,
                 gdk::Gravity::NorthWest,
                 gdk::Gravity::NorthWest,
-                None,
+                Some(&event),
             );
         }
 


### PR DESCRIPTION
This PR fixes: 

Whenever a context menu appears, a warning message is output in the terminal.
```
(app:174605) Gtk-WARNING **: 14:21:21.316: no trigger event for menu popup
```

---

This PR code is from `tauri/muda` 

https://github.com/tauri-apps/muda/blob/37f8fca135d0a7d61769bfeec73e033d67c38cb9/src/platform_impl/gtk/mod.rs#L1382-L1398